### PR TITLE
:calendar: 2021-06-11 :sparkles: usama251993-feature/cdk-implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,8 @@
         "open": "^7.0.3",
         "source-map-explorer": "^2.5.2",
         "tailwindcss": "2.1.3",
-        "typescript": "~4.2.3"
+        "typescript": "~4.2.3",
+        "webpack-bundle-analyzer": "^4.4.2"
       }
     },
     "node_modules/@angular-devkit/architect": {
@@ -2954,6 +2955,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.15",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
+      "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
+      "dev": true
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -14228,6 +14235,15 @@
         "yaml": "^1.10.0"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -18773,6 +18789,20 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
     },
+    "node_modules/sirv": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.12.tgz",
+      "integrity": "sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.15",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -20864,6 +20894,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -21689,6 +21728,117 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz",
+      "integrity": "sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/acorn-walk": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+      "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -25245,6 +25395,12 @@
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.2.tgz",
       "integrity": "sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==",
+      "dev": true
+    },
+    "@polka/url": {
+      "version": "1.0.0-next.15",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
+      "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
       "dev": true
     },
     "@protobufjs/aspromise": {
@@ -34256,6 +34412,12 @@
         "yaml": "^1.10.0"
       }
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -37661,6 +37823,17 @@
         }
       }
     },
+    "sirv": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.12.tgz",
+      "integrity": "sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.15",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -39285,6 +39458,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -40011,6 +40190,86 @@
           "requires": {
             "source-list-map": "^2.0.1",
             "source-map": "^0.6.1"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz",
+      "integrity": "sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+          "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "itinerary-assistant",
   "version": "1.0.0",
   "scripts": {
-    "analyze": "source-map-explorer dist/*.{js,css} --no-border-checks",
-    "build:dev": "ng build --configuration=development --source-map",
-    "build:stats": "ng build --source-map",
+    "analyze:sme": "source-map-explorer dist/*.{js,css} --no-border-checks",
+    "analyze:wba": "webpack-bundle-analyzer dist/stats.json",
+    "build:dev": "ng build --configuration=development --source-map --stats-json",
+    "build:stats": "ng build --source-map --stats-json",
     "build": "ng build",
     "deploy": "ng deploy",
     "e2e": "ng e2e",
@@ -67,6 +68,7 @@
     "open": "^7.0.3",
     "source-map-explorer": "^2.5.2",
     "tailwindcss": "2.1.3",
-    "typescript": "~4.2.3"
+    "typescript": "~4.2.3",
+    "webpack-bundle-analyzer": "^4.4.2"
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,25 +2,31 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { LumberjackModule } from '@ngworker/lumberjack';
+import { LumberjackConsoleDriverModule } from '@ngworker/lumberjack/console-driver';
+
 import { AppFireModule } from '@shared/modules/fire/fire.module';
+import { AppMaterialModule } from '@shared/modules/material/material.module';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { LumberjackModule } from '@ngworker/lumberjack';
-import { LumberjackConsoleDriverModule } from '@ngworker/lumberjack/console-driver';
 
 const DECLARATIONS = [AppComponent];
 const IMPORTS = [
   BrowserModule,
   BrowserAnimationsModule,
 
+  LumberjackModule.forRoot(),
+  LumberjackConsoleDriverModule.forRoot(),
+
   AppRoutingModule,
-  AppFireModule
+  AppFireModule,
+  AppMaterialModule
 ];
 
 @NgModule({
   declarations: [...DECLARATIONS],
-  imports: [...IMPORTS, LumberjackModule.forRoot(), LumberjackConsoleDriverModule.forRoot()],
+  imports: [...IMPORTS],
   bootstrap: [...DECLARATIONS]
 })
 export class AppModule { }

--- a/src/app/core/components/footer/ia-core-footer-container/ia-core-footer-container.component.ts
+++ b/src/app/core/components/footer/ia-core-footer-container/ia-core-footer-container.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import { IaCoreFooterAssetsModel } from '@ia-core/models/footer/ia-core-footer.model';
 import { IaCoreFooterService } from '@ia-core/services/footer/ia-core-footer/ia-core-footer.service';
+import { IaCoreFooterAssetsModel, IaCoreFooterFlagsModel } from '@ia-core/models/footer/ia-core-footer.model';
 
 /**
  * TODO: :monocle_face: Documentation Required
@@ -15,9 +15,9 @@ import { IaCoreFooterService } from '@ia-core/services/footer/ia-core-footer/ia-
 @Component({
   selector: 'app-ia-core-footer-container',
   template: `<app-ia-core-footer [assets]         = "assets$ | async"
-                                 (copyDiscordID$) = "copyDiscordID"
-                                 (copyEmailID$)   = "copyEmailID"></app-ia-core-footer>`,
-  providers: [IaCoreFooterService]
+                                 [flags]          = "flags$  | async"
+                                 (copyDiscordID$) = "copyDiscordID()"
+                                 (copyEmailID$)   = "copyEmailID()"></app-ia-core-footer>`
 })
 export class IaCoreFooterContainerComponent implements OnInit {
 
@@ -28,6 +28,8 @@ export class IaCoreFooterContainerComponent implements OnInit {
    * @memberof IaCoreFooterContainerComponent
    */
   assets$: Observable<IaCoreFooterAssetsModel>;
+
+  flags$: Observable<IaCoreFooterFlagsModel>;
 
   /**
    * Creates an instance of IaCoreFooterContainerComponent.
@@ -44,8 +46,10 @@ export class IaCoreFooterContainerComponent implements OnInit {
    */
   ngOnInit(): void {
     this._service.fetchAssets();
+    this._service.resetFlags();
 
     this.assets$ = this._service.watchAssets$();
+    this.flags$ = this._service.watchFlags$();
   }
 
   /**

--- a/src/app/core/components/footer/ia-core-footer-container/ia-core-footer/ia-core-footer.component.ts
+++ b/src/app/core/components/footer/ia-core-footer-container/ia-core-footer/ia-core-footer.component.ts
@@ -2,7 +2,10 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { BehaviorSubject } from 'rxjs';
 
-import { IaCoreFooterAssetsModel, IaCoreFooterIcon } from '@ia-core/models/footer/ia-core-footer.model';
+import {
+  IaCoreFooterAssetsModel, IaCoreFooterFlagsModel,
+  IaCoreFooterIcon
+} from '@ia-core/models/footer/ia-core-footer.model';
 
 // TODO: Hierarachical Modularization
 import { AppFaIconModel } from '@shared/models/icon/app-icon.model';
@@ -34,11 +37,29 @@ export class IaCoreFooterComponent implements OnInit {
   /**
    * TODO: :monocle_face: Documentation Required
    *
+   * @private
+   * @type {BehaviorSubject<IaCoreFooterFlagsModel>}
+   * @memberof IaCoreFooterComponent
+   */
+  private _flags$: BehaviorSubject<IaCoreFooterFlagsModel> = new BehaviorSubject<IaCoreFooterFlagsModel>(null);
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
    * @memberof IaCoreFooterComponent
    */
   @Input()
   set assets(value: IaCoreFooterAssetsModel) { this._assets$.next(value); }
   get assets(): IaCoreFooterAssetsModel { return this._assets$.getValue(); }
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @memberof IaCoreFooterComponent
+   */
+  @Input()
+  set flags(value: IaCoreFooterFlagsModel) { this._flags$.next(value); }
+  get flags(): IaCoreFooterFlagsModel { return this._flags$.getValue(); }
 
   /**
    * TODO: :monocle_face: Documentation Required

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { AppSharedModule } from '@shared/shared.module';
+import { AppMaterialModule } from '@shared/modules/material/material.module';
 
 import { IaCoreRoutingModule } from './core-routing.module';
 import { IaCoreIconModule } from '@ia-core/modules/icons/ia-core-icon/ia-core-icon.module';
-import { IaCoreMaterialModule } from './modules/material/ia-core-material/ia-core-material.module';
 
 import { IaCoreShellComponent } from './components/shell/ia-core-shell.component';
 
@@ -23,7 +22,6 @@ import { IaCoreMockTripListComponent } from './components/mock/ia-core-mock-trip
 import { IaCoreTodoContainerComponent } from './components/todo/ia-core-todo-container/ia-core-todo-container.component';
 import { IaCoreTodoComponent } from './components/todo/ia-core-todo-container/ia-core-todo/ia-core-todo.component';
 
-
 const DECLARATIONS = [
   IaCoreShellComponent,
 
@@ -37,19 +35,21 @@ const DECLARATIONS = [
   IaCoreFooterComponent,
 
   IaCoreMockTripListContainerComponent,
-  IaCoreMockTripListComponent
+  IaCoreMockTripListComponent,
+
+  IaCoreTodoContainerComponent,
+  IaCoreTodoComponent
 ];
 
 const IMPORTS = [
   CommonModule,
+  AppMaterialModule,
   IaCoreRoutingModule,
-  AppSharedModule,
-  IaCoreIconModule,
-  IaCoreMaterialModule
+  IaCoreIconModule
 ];
 
 @NgModule({
-  declarations: [...DECLARATIONS, IaCoreTodoContainerComponent, IaCoreTodoComponent],
+  declarations: [...DECLARATIONS],
   imports: [...IMPORTS]
 })
 export class IaCoreModule { }

--- a/src/app/core/models/footer/ia-core-footer.model.ts
+++ b/src/app/core/models/footer/ia-core-footer.model.ts
@@ -1,5 +1,6 @@
 import { AppFaIconModel } from '@shared/models/icon/app-icon.model';
 import { AppImageModel } from '@shared/models/image/app-image.model';
+import { IaCoreFlagModel, DEFAULT_IA_CORE_FLAG } from '@ia-core/models/ia-core.model';
 
 /**
  * TODO: Create common models for `ia-core.module`
@@ -142,4 +143,13 @@ export const DEFAULT_IA_CORE_FOOTER_ASSETS: IaCoreFooterAssetsModel = {
   linkedin: null,
   discord: null,
   email: null
+};
+
+export interface IaCoreFooterFlagsModel {
+  discord: IaCoreFlagModel;
+  email: IaCoreFlagModel;
+}
+
+export const DEFAULT_IA_CORE_FOOTER_FLAGS: IaCoreFooterFlagsModel = {
+  discord: { ...DEFAULT_IA_CORE_FLAG }, email: { ...DEFAULT_IA_CORE_FLAG }
 };

--- a/src/app/core/models/ia-core.model.ts
+++ b/src/app/core/models/ia-core.model.ts
@@ -2,6 +2,7 @@ import { AppButtonModel, DEFAULT_APP_BUTTON } from '@shared/models/button/app-bu
 import { AppFaIconModel, DEFAULT_FA_ICON } from '@shared/models/icon/app-icon.model';
 import { AppImageModel, DEFAULT_APP_IMAGE } from '@shared/models/image/app-image.model';
 import { AppRouterPayloadModel } from '@shared/models/router/app-router.model';
+import { AppFlagModel, DEFAULT_APP_FLAG } from '@shared/models/flag/app-flag.model';
 
 /**
  * Icon in `ia-core` module.
@@ -72,3 +73,7 @@ export const DEFAULT_IA_BUTTON: IaCoreButtonModel = { ...DEFAULT_APP_BUTTON };
 export interface IaCoreImageModel extends AppImageModel { }
 
 export const DEFAULT_IA_IMAGE: IaCoreImageModel = { ...DEFAULT_APP_IMAGE };
+
+export interface IaCoreFlagModel extends AppFlagModel { }
+
+export const DEFAULT_IA_CORE_FLAG: IaCoreFlagModel = { ...DEFAULT_APP_FLAG };

--- a/src/app/core/modules/material/ia-core-material/ia-core-material.module.ts
+++ b/src/app/core/modules/material/ia-core-material/ia-core-material.module.ts
@@ -18,21 +18,21 @@ import { NgModule } from '@angular/core';
 
 // *************** NAVIGATION ***************
 // import { MatMenuModule } from '@angular/material/menu'
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatToolbarModule } from '@angular/material/toolbar';
+// import { MatSidenavModule } from '@angular/material/sidenav';
+// import { MatToolbarModule } from '@angular/material/toolbar';
 
 // *************** LAYOUT ***************
-import { MatCardModule } from '@angular/material/card';
+// import { MatCardModule } from '@angular/material/card';
 // import { MatDividerModule } from '@angular/material/divider'
 // import { MatExpansionModule } from '@angular/material/expansion'
 // import { MatGridListModule } from '@angular/material/grid-list'
-import { MatListModule } from '@angular/material/list';
+// import { MatListModule } from '@angular/material/list';
 // import { MatStepperModule } from '@angular/material/stepper'
 // import { MatTabsModule } from '@angular/material/tabs'
 // import { MatTreeModule } from '@angular/material/tree'
 
 // *************** BUTTONS & INDICATORS ***************
-import { MatButtonModule } from '@angular/material/button';
+// import { MatButtonModule } from '@angular/material/button';
 // import { MatButtonToggleModule } from '@angular/material/button-toggle'
 // import { MatBadgeModule } from '@angular/material/badge'
 // import { MatChipsModule } from '@angular/material/chips'
@@ -45,7 +45,7 @@ import { MatButtonModule } from '@angular/material/button';
 // import { MatBottomSheetModule } from '@angular/material/bottom-sheet'
 // import { MatDialogModule } from '@angular/material/dialog'
 // import { MatSnackBarModule } from '@angular/material/snack-bar'
-import { MatTooltipModule } from '@angular/material/tooltip';
+// import { MatTooltipModule } from '@angular/material/tooltip';
 
 // *************** DATA TABLE ***************
 // import { MatPaginatorModule } from '@angular/material/paginator'
@@ -65,17 +65,17 @@ const MATERIAL_MODULES = [
   // MatSliderModule,
   // MatSlideToggleModule,
   // MatMenuModule,
-  MatSidenavModule,
-  MatToolbarModule,
-  MatCardModule,
+  // MatSidenavModule,
+  // MatToolbarModule,
+  // MatCardModule,
   // MatDividerModule,
   // MatExpansionModule,
   // MatGridListModule,
-  MatListModule,
+  // MatListModule,
   // MatStepperModule,
   // MatTabsModule,
   // MatTreeModule,
-  MatButtonModule,
+  // MatButtonModule,
   // MatButtonToggleModule,
   // MatBadgeModule,
   // MatChipsModule,
@@ -86,7 +86,7 @@ const MATERIAL_MODULES = [
   // MatBottomSheetModule,
   // MatDialogModule,
   // MatSnackBarModule,
-  MatTooltipModule
+  // MatTooltipModule
   // MatPaginatorModule,
   // MatSortModule,
   // MatTableModule
@@ -95,6 +95,12 @@ const MATERIAL_MODULES = [
 const IMPORTS = [...MATERIAL_MODULES];
 const EXPORTS = [...MATERIAL_MODULES];
 
+/**
+ * @redundant Remove this module
+ *
+ * @export
+ * @class IaCoreMaterialModule
+ */
 @NgModule({
   imports: [...IMPORTS],
   exports: [...EXPORTS]

--- a/src/app/core/services/common/clipboard/ia-core-clipboard/ia-core-clipboard.service.spec.ts
+++ b/src/app/core/services/common/clipboard/ia-core-clipboard/ia-core-clipboard.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IaCoreClipboardService } from './ia-core-clipboard.service';
+
+describe('IaCoreClipboardService', () => {
+  let service: IaCoreClipboardService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(IaCoreClipboardService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/common/clipboard/ia-core-clipboard/ia-core-clipboard.service.ts
+++ b/src/app/core/services/common/clipboard/ia-core-clipboard/ia-core-clipboard.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { AppClipboardService } from '@shared/services/clipboard/app-clipboard/app-clipboard.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IaCoreClipboardService {
+
+  constructor(
+    private _clipboard: AppClipboardService
+  ) { }
+
+  copy(text: string): boolean {
+    return this._clipboard.copy(text);
+  }
+}

--- a/src/app/core/services/common/snackbar/ia-core-snackbar/ia-core-snackbar.service.spec.ts
+++ b/src/app/core/services/common/snackbar/ia-core-snackbar/ia-core-snackbar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IaCoreSnackbarService } from './ia-core-snackbar.service';
+
+describe('IaCoreSnackbarService', () => {
+  let service: IaCoreSnackbarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(IaCoreSnackbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/common/snackbar/ia-core-snackbar/ia-core-snackbar.service.ts
+++ b/src/app/core/services/common/snackbar/ia-core-snackbar/ia-core-snackbar.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBarConfig } from '@angular/material/snack-bar';
+import { AppSnackbarService } from '@shared/services/snackbar/app-snackbar/app-snackbar.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IaCoreSnackbarService {
+
+  constructor(
+    private _snackbar: AppSnackbarService
+  ) { }
+
+  openSnackbar<GenericSnackbarData>(snackbar: { message: string; action: string; config: MatSnackBarConfig<GenericSnackbarData>; }): void {
+    this._snackbar.openSnackbar({ ...snackbar });
+  }
+}

--- a/src/app/core/services/footer/ia-core-footer/ia-core-footer.service.ts
+++ b/src/app/core/services/footer/ia-core-footer/ia-core-footer.service.ts
@@ -4,9 +4,17 @@ import { BehaviorSubject, Observable } from 'rxjs';
 
 import { AUTHOR } from '@shared/constants/app.constants';
 
-import { DEFAULT_IA_CORE_FOOTER_ASSETS, IaCoreFooterAssetsModel } from '@ia-core/models/footer/ia-core-footer.model';
+import { IaCoreClipboardService } from '@ia-core/services/common/clipboard/ia-core-clipboard/ia-core-clipboard.service';
+// import { DEFAULT_IA_CORE_FLAG } from '@ia-core/models/ia-core.model';
+import {
+  IaCoreFooterAssetsModel, DEFAULT_IA_CORE_FOOTER_ASSETS,
+  IaCoreFooterFlagsModel, DEFAULT_IA_CORE_FOOTER_FLAGS
+} from '@ia-core/models/footer/ia-core-footer.model';
+import { IaCoreSnackbarService } from '@ia-core/services/common/snackbar/ia-core-snackbar/ia-core-snackbar.service';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class IaCoreFooterService {
 
   /**
@@ -22,17 +30,38 @@ export class IaCoreFooterService {
    * TODO: :monocle_face: Documentation Required
    *
    * @private
+   * @type {BehaviorSubject<IaCoreFooterFlagsModel>}
+   * @memberof IaCoreFooterService
+   */
+  private _flags$: BehaviorSubject<IaCoreFooterFlagsModel> = new BehaviorSubject<IaCoreFooterFlagsModel>(null);
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @private
    * @type {IaCoreFooterAssetsModel}
    * @memberof IaCoreFooterService
    */
   private _assets: IaCoreFooterAssetsModel = { ...DEFAULT_IA_CORE_FOOTER_ASSETS };
 
   /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @private
+   * @type {IaCoreFooterFlagsModel}
+   * @memberof IaCoreFooterService
+   */
+  private _flags: IaCoreFooterFlagsModel = { ...DEFAULT_IA_CORE_FOOTER_FLAGS };
+
+  /**
    * Creates an instance of IaCoreFooterService.
    * 
    * @memberof IaCoreFooterService
    */
-  constructor() { }
+  constructor(
+    private _clipboard: IaCoreClipboardService,
+    private _snackbar: IaCoreSnackbarService
+  ) { }
 
   /**
    * TODO: :monocle_face: Documentation Required
@@ -46,30 +75,25 @@ export class IaCoreFooterService {
       madeWith: 'Made with',
 
       heart: {
-        name: '',
-        url: '',
+        name: '', url: '',
         icon: { style: 'fas', name: 'heart' }
       },
       using: 'using',
 
       angular: {
-        name: 'Angular',
-        url: 'https://angular.io/',
+        name: 'Angular', url: 'https://angular.io/',
         icon: { style: 'fab', name: 'angular' }
       },
       tailwind: {
-        name: 'Tailwind',
-        url: 'https://tailwindcss.com/',
+        name: 'Tailwind', url: 'https://tailwindcss.com/',
         icon: { src: 'assets/media/images/tailwindcss.svg', alt: 'Tailwind' }
       },
       fontawesome: {
-        name: 'Font Awesome',
-        url: 'https://fontawesome.com/',
+        name: 'Font Awesome', url: 'https://fontawesome.com/',
         icon: { style: 'fab', name: 'fort-awesome-alt' }
       },
       firebase: {
-        name: 'Firebase',
-        url: 'https://firebase.google.com/',
+        name: 'Firebase', url: 'https://firebase.google.com/',
         icon: { src: 'assets/media/images/firebase.svg', alt: 'Firebase' }
       },
 
@@ -77,23 +101,19 @@ export class IaCoreFooterService {
       author: AUTHOR.FULLNAME,
 
       github: {
-        name: 'GitHub',
-        url: `https://github.com/${AUTHOR.GITHUB}`,
+        name: 'GitHub', url: `https://github.com/${AUTHOR.GITHUB}`,
         icon: { style: 'fab', name: 'github' }
       },
       linkedin: {
-        name: 'LinkedIn',
-        url: `https://www.linkedin.com/in/${AUTHOR.LINKEDIN}`,
+        name: 'LinkedIn', url: `https://www.linkedin.com/in/${AUTHOR.LINKEDIN}`,
         icon: { style: 'fab', name: 'linkedin' }
       },
       discord: {
-        name: 'Discord',
-        url: AUTHOR.DISCORD,
+        name: 'Discord', url: AUTHOR.DISCORD,
         icon: { style: 'fab', name: 'discord' }
       },
       email: {
-        name: 'E-mail',
-        url: AUTHOR.EMAIL,
+        name: 'E-mail', url: AUTHOR.EMAIL,
         icon: { style: 'fas', name: 'envelope-open-text' }
       }
     };
@@ -117,7 +137,16 @@ export class IaCoreFooterService {
    * @memberof IaCoreFooterService
    */
   copyDiscordID(): void {
+    this._clipboard.copy(AUTHOR.DISCORD);
 
+    /**
+     * Optimize for scalable usage
+     */
+    this._snackbar.openSnackbar({ message: 'Discord ID Copied!', action: 'OK', config: { horizontalPosition: 'center', verticalPosition: 'bottom', duration: 2500 } });
+
+    // this.setFlags({ ...this._flags, discord: { ...DEFAULT_IA_CORE_FLAG } });
+    // const isCopied: boolean = this._clipboard.copy(AUTHOR.DISCORD);    
+    // this.setFlags({ ...this._flags, discord: { ...DEFAULT_IA_CORE_FLAG, success: isCopied, fail: !isCopied } });
   }
 
   /**
@@ -126,7 +155,46 @@ export class IaCoreFooterService {
    * @memberof IaCoreFooterService
    */
   copyEmailID(): void {
+    this._clipboard.copy(AUTHOR.EMAIL);
 
+    /**
+     * Optimize for scalable usage
+     */
+    this._snackbar.openSnackbar({ message: 'Email ID Copied!', action: 'OK', config: { horizontalPosition: 'center', verticalPosition: 'bottom', duration: 2500 } });
+
+    // this.setFlags({ ...this._flags, email: { ...DEFAULT_IA_CORE_FLAG } });
+    // const isCopied: boolean = this._clipboard.copy(AUTHOR.EMAIL);
+    // this.setFlags({ ...this._flags, email: { ...DEFAULT_IA_CORE_FLAG, success: isCopied, fail: !isCopied } });
+  }
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @param {IaCoreFooterFlagsModel} flags
+   * @memberof IaCoreFooterService
+   */
+  setFlags(flags: IaCoreFooterFlagsModel): void {
+    this._flags = { ...flags ?? DEFAULT_IA_CORE_FOOTER_FLAGS };
+    this._flags$.next(this._flags);
+  }
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @memberof IaCoreFooterService
+   */
+  resetFlags(): void {
+    this.setFlags(DEFAULT_IA_CORE_FOOTER_FLAGS);
+  }
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @return {*}  {Observable<IaCoreFooterFlagsModel>}
+   * @memberof IaCoreFooterService
+   */
+  watchFlags$(): Observable<IaCoreFooterFlagsModel> {
+    return this._flags$.asObservable();
   }
 
   /**

--- a/src/app/shared/models/flag/app-flag.model.ts
+++ b/src/app/shared/models/flag/app-flag.model.ts
@@ -1,0 +1,35 @@
+/**
+ * TODO: :monocle_face: Documentation Required
+ *
+ * @export
+ * @interface AppFlagModel
+ */
+export interface AppFlagModel {
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @type {boolean}
+   * @memberof AppFlagModel
+   */
+  progress: boolean;
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @type {boolean}
+   * @memberof AppFlagModel
+   */
+  success: boolean;
+
+  /**
+   * TODO: :monocle_face: Documentation Required
+   *
+   * @type {boolean}
+   * @memberof AppFlagModel
+   */
+  fail: boolean;
+}
+
+export const DEFAULT_APP_FLAG: AppFlagModel = {
+  progress: false, success: false, fail: false
+};

--- a/src/app/shared/modules/fontawesome/fontawesome.module.ts
+++ b/src/app/shared/modules/fontawesome/fontawesome.module.ts
@@ -1,15 +1,15 @@
-import { FaIconLibrary, FontAwesomeModule } from '@fortawesome/angular-fontawesome'
-// import { fas } from '@fortawesome/free-solid-svg-icons'
-// import { far } from '@fortawesome/free-regular-svg-icons'
-// import { fab } from '@fortawesome/free-brands-svg-icons'
-import { NgModule } from '@angular/core'
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { NgModule } from '@angular/core';
 
+/**
+ * @redundant Remove this module
+ *
+ * @export
+ * @class AppFontAwesomeModule
+ */
 @NgModule({
   imports: [FontAwesomeModule],
   exports: [FontAwesomeModule]
 })
 export class AppFontAwesomeModule {
-  // constructor(lib: FaIconLibrary) {
-  //   lib.addIconPacks(fas, far, fab)
-  // }
 }

--- a/src/app/shared/modules/material/material.module.ts
+++ b/src/app/shared/modules/material/material.module.ts
@@ -5,98 +5,110 @@
 
 import { NgModule } from '@angular/core';
 // *************** FORM CONTROLS ***************
-// import { MatAutocompleteModule } from '@angular/material/autocomplete'
-// import { MatCheckboxModule } from '@angular/material/checkbox';
-// import { MatDatepickerModule } from '@angular/material/datepicker';
-// import { MatNativeDateModule } from '@angular/material/core';             //FROM ANGULAR CORE
-// import { MatFormFieldModule } from '@angular/material/form-field';
-// import { MatInputModule } from '@angular/material/input';
-// import { MatRadioModule } from '@angular/material/radio';
-// import { MatSelectModule } from '@angular/material/select';
-// import { MatSliderModule } from '@angular/material/slider';
-// import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';             //FROM ANGULAR CORE
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 // *************** NAVIGATION ***************
-// import { MatMenuModule } from '@angular/material/menu'
-// import { MatSidenavModule } from '@angular/material/sidenav';
-// import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatMenuModule } from '@angular/material/menu';
+
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 // *************** LAYOUT ***************
-// import { MatCardModule } from '@angular/material/card'
-// import { MatDividerModule } from '@angular/material/divider'
-// import { MatExpansionModule } from '@angular/material/expansion'
-// import { MatGridListModule } from '@angular/material/grid-list'
-// import { MatListModule } from '@angular/material/list'
-// import { MatStepperModule } from '@angular/material/stepper'
-// import { MatTabsModule } from '@angular/material/tabs'
-// import { MatTreeModule } from '@angular/material/tree'
+import { MatCardModule } from '@angular/material/card';
+
+import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatGridListModule } from '@angular/material/grid-list';
+
+import { MatListModule } from '@angular/material/list';
+
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatTreeModule } from '@angular/material/tree';
 
 // *************** BUTTONS & INDICATORS ***************
-// import { MatButtonModule } from '@angular/material/button';
-// import { MatButtonToggleModule } from '@angular/material/button-toggle'
-// import { MatBadgeModule } from '@angular/material/badge'
-// import { MatChipsModule } from '@angular/material/chips'
-// import { MatIconModule } from '@angular/material/icon'
-// import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
-// import { MatProgressBarModule } from '@angular/material/progress-bar'
-// import { MatRippleModule } from '@angular/material/core'
+import { MatButtonModule } from '@angular/material/button';
+
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatRippleModule } from '@angular/material/core';
 
 // *************** POPUPS & MODALS ***************
-// import { MatBottomSheetModule } from '@angular/material/bottom-sheet'
-// import { MatDialogModule } from '@angular/material/dialog'
-// import { MatSnackBarModule } from '@angular/material/snack-bar'
-// import { MatTooltipModule } from '@angular/material/tooltip'
+import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 // *************** DATA TABLE ***************
-// import { MatPaginatorModule } from '@angular/material/paginator'
-// import { MatSortModule } from '@angular/material/sort'
-// import { MatTableModule } from '@angular/material/table'
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
 
 
-const COMMON = [
-  // MatAutocompleteModule,
-  // MatCheckboxModule,
-  // MatDatepickerModule,
-  // MatNativeDateModule,
-  // MatFormFieldModule,
-  // MatInputModule,
-  // MatRadioModule,
-  // MatSelectModule,
-  // MatSliderModule,
-  // MatSlideToggleModule,
-  // MatMenuModule,
-  // MatSidenavModule,
-  // MatToolbarModule,
-  // MatCardModule,
-  // MatDividerModule,
-  // MatExpansionModule,
-  // MatGridListModule,
-  // MatListModule,
-  // MatStepperModule,
-  // MatTabsModule,
-  // MatTreeModule,
-  // MatButtonModule,
-  // MatButtonToggleModule,
-  // MatBadgeModule,
-  // MatChipsModule,
-  // MatIconModule,
-  // MatProgressSpinnerModule,
-  // MatProgressBarModule,
-  // MatRippleModule,
-  // MatBottomSheetModule,
-  // MatDialogModule,
-  // MatSnackBarModule,
-  // MatTooltipModule,
-  // MatPaginatorModule,
-  // MatSortModule,
-  // MatTableModule
+const MATERIAL_MODULES = [
+  MatAutocompleteModule,
+  MatCheckboxModule,
+  MatDatepickerModule,
+  MatNativeDateModule,
+  MatFormFieldModule,
+  MatInputModule,
+  MatRadioModule,
+  MatSelectModule,
+  MatSliderModule,
+  MatSlideToggleModule,
+  MatMenuModule,
+  MatSidenavModule,
+  MatToolbarModule,
+  MatCardModule,
+  MatDividerModule,
+  MatExpansionModule,
+  MatGridListModule,
+  MatListModule,
+  MatStepperModule,
+  MatTabsModule,
+  MatTreeModule,
+  MatButtonModule,
+  MatButtonToggleModule,
+  MatBadgeModule,
+  MatChipsModule,
+  MatIconModule,
+  MatProgressSpinnerModule,
+  MatProgressBarModule,
+  MatRippleModule,
+  MatBottomSheetModule,
+  MatDialogModule,
+  MatSnackBarModule,
+  MatTooltipModule,
+  MatPaginatorModule,
+  MatSortModule,
+  MatTableModule
 ];
 
-const IMPORTS = [...COMMON];
-const EXPORTS = [...COMMON];
+// const IMPORTS = [...MATERIAL_MODULES];
+const EXPORTS = [...MATERIAL_MODULES];
 
+/**
+ * @watch Watch the size of this module until a good optimization is in place
+ *
+ * @export
+ * @class AppMaterialModule
+ */
 @NgModule({
-  imports: [...IMPORTS],
+  // imports: [...IMPORTS],
   exports: [...EXPORTS]
 })
 export class AppMaterialModule { }

--- a/src/app/shared/services/clipboard/app-clipboard/app-clipboard.service.spec.ts
+++ b/src/app/shared/services/clipboard/app-clipboard/app-clipboard.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AppClipboardService } from './app-clipboard.service';
+
+describe('AppClipboardService', () => {
+  let service: AppClipboardService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppClipboardService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/clipboard/app-clipboard/app-clipboard.service.ts
+++ b/src/app/shared/services/clipboard/app-clipboard/app-clipboard.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Clipboard } from '@angular/cdk/clipboard';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppClipboardService {
+
+  constructor(
+    private _clipboard: Clipboard
+  ) { }
+
+  copy(text: string): boolean {
+    return this._clipboard.copy(text);
+  }
+}

--- a/src/app/shared/services/snackbar/app-snackbar/app-snackbar.service.spec.ts
+++ b/src/app/shared/services/snackbar/app-snackbar/app-snackbar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AppSnackbarService } from './app-snackbar.service';
+
+describe('AppSnackbarService', () => {
+  let service: AppSnackbarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppSnackbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/snackbar/app-snackbar/app-snackbar.service.ts
+++ b/src/app/shared/services/snackbar/app-snackbar/app-snackbar.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppSnackbarService {
+
+  constructor(
+    private _snackbar: MatSnackBar
+  ) { }
+
+  openSnackbar<GenericSnackbarData>(snackbar: { message: string; action: string; config: MatSnackBarConfig<GenericSnackbarData>; }): void {
+    this._snackbar.open(snackbar.message, snackbar.action, { ...snackbar.config });
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,15 +1,15 @@
 import { NgModule } from '@angular/core';
 
-import { AppFontAwesomeModule } from './modules/fontawesome/fontawesome.module';
-import { AppMaterialModule } from './modules/material/material.module';
-
 const DECLARATIONS = [];
 
-const IMPORTS = [
-  AppMaterialModule,
-  AppFontAwesomeModule
-];
+const IMPORTS = [];
 
+/**
+ * @redundant - will be used when shared components and/or ngrx/ngxs state are in action
+ *
+ * @export
+ * @class AppSharedModule
+ */
 @NgModule({
   declarations: [...DECLARATIONS],
   imports: [...IMPORTS],


### PR DESCRIPTION
### Implemented `CdkClipboard` and `MatSnackbar`

#### CHANGES
1. :sparkles: Implemented `Clipboard`
   - `AppClipboardService` for app-level implementation
   - `IaCoreClipboardService` for module-level implementation
2. :sparkles: Implemented `MatSnackbar`
   - `AppSnackbarService` for app-level implementation
   - `IaCoreSnackbarService` for module-level implementation
3. :recycle: Reimplemented `webpack-bundle-analyzer` for analysis of code
   - `webpack-bundle-analyzer` and `source-map-explorer` would be kept together for now
4. :thinking: Using all the imports from `@angular/material` does no harm yet
5. :+1: A single instance of `AppMaterialModule` is now made available across all the modules
6. :sparkles: Implemented `IaCoreFooterFlag`s
7. :wastebasket: `AppSharedModule` is now redundant since it does not contain any shared resource
8. :wastebasket: `IaCoreMaterialModule` is now redundant
9. :wastebasket: `AppFontAwesomeModule` is now redundant

22 :sparkles:

Closes #28 